### PR TITLE
V1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [1.0.2] - 25 Nov 2020
+
+* Deprecated showCurrencyListBottomSheet. Use `showCurrencyPicker` instead.
+* Add currency filter option.
+    - Can be used to uses filter the currencies list.
+    - It takes a list of currency code.
+      ```Dart
+      showCurrencyPicker(
+        context: context,
+        onSelect: (Currency currency) {
+          print('Select currency: ${currency.name}');
+        },
+        currencyFilter: <String> ['EUR', 'GBP', 'USD', 'AUD', 'CAD', 'JPY', 'HKD', 'CHF', 'SEK', 'ILS'],
+      );
+      ``` 
+
 ## [1.0.1] - 15 Nov 2020
 
 * Implement search.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A flutter package to select a currency from a list of currencies.
  Add the package to your pubspec.yaml:
 
  ```yaml
- currency_picker: ^1.0.1
+ currency_picker: ^1.0.2
  ```
  
  In your dart file, import the library:
@@ -19,9 +19,9 @@ A flutter package to select a currency from a list of currencies.
  ```Dart
  import 'package:currency_picker/currency_picker.dart';
  ``` 
-  Show currency picker using `showCurrencyListBottomSheet`:
+  Show currency picker using `showCurrencyPicker`:
 ```Dart
-showCurrencyListBottomSheet(
+showCurrencyPicker(
    context: context,
    onSelect: (Currency currency) {
       print('Select currency: ${currency.name}');
@@ -31,6 +31,16 @@ showCurrencyListBottomSheet(
 
 ### Parameters:
 * `onSelect`: Called when a currency is select. The currency picker passes the new value to the callback (required)
+* `currencyFilter`: Can be used to uses filter the Currency list (optional).
+  ```Dart
+   showCurrencyPicker(
+      context: context,
+      onSelect: (Currency currency) {
+         print('Select currency: ${currency.name}');
+      },
+      currencyFilter: <String>['EUR', 'GBP', 'USD', 'AUD', 'CAD', 'JPY', 'HKD', 'CHF', 'SEK', 'ILS'],
+   );
+  ``` 
 
 ## Contributions
 Contributions of any kind are more than welcome! Feel free to fork and improve currency_picker in any way you want, make a pull request, or open an issue.

--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,7 @@ A flutter package to select a currency from a list of currencies.
  Add the package to your pubspec.yaml:
 
  ```yaml
- currency_picker: ^1.0.0
+ currency_picker: ^1.0.2
  ```
  
  In your dart file, import the library:
@@ -19,9 +19,9 @@ A flutter package to select a currency from a list of currencies.
  ```Dart
  import 'package:currency_picker/currency_picker.dart';
  ``` 
-  Show currency picker using `showCurrencyListBottomSheet`:
+  Show currency picker using `showCurrencyPicker`:
 ```Dart
-showCurrencyListBottomSheet(
+showCurrencyPicker(
    context: context,
    onSelect: (Currency currency) {
       print('Select currency: ${currency.name}');
@@ -31,6 +31,16 @@ showCurrencyListBottomSheet(
 
 ### Parameters:
 * `onSelect`: Called when a currency is select. The currency picker passes the new value to the callback (required)
+* `currencyFilter`: Can be used to uses filter the Currency list (optional).
+  ```Dart
+   showCurrencyPicker(
+      context: context,
+      onSelect: (Currency currency) {
+         print('Select currency: ${currency.name}');
+      },
+      currencyFilter: <String>['EUR', 'GBP', 'USD', 'AUD', 'CAD', 'JPY', 'HKD', 'CHF', 'SEK', 'ILS'],
+   );
+  ``` 
 
 ## Contributions
 Contributions of any kind are more than welcome! Feel free to fork and improve currency_picker in any way you want, make a pull request, or open an issue.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,7 @@ class HomePage extends StatelessWidget {
               onSelect: (Currency currency) {
                 print('Select currency: ${currency.name}');
               },
+              currencyFilter: ['cad', 'cop', 'dop'],
             );
           },
           child: const Text('Show currency picker'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,7 +32,6 @@ class HomePage extends StatelessWidget {
               onSelect: (Currency currency) {
                 print('Select currency: ${currency.name}');
               },
-              currencyFilter: ['cad', 'cop', 'dop'],
             );
           },
           child: const Text('Show currency picker'),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,7 +27,7 @@ class HomePage extends StatelessWidget {
       body: Center(
         child: RaisedButton(
           onPressed: () {
-            showCurrencyListBottomSheet(
+            showCurrencyPicker(
               context: context,
               onSelect: (Currency currency) {
                 print('Select currency: ${currency.name}');

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.0.2"
   fake_async:
     dependency: transitive
     description:

--- a/lib/currency_picker.dart
+++ b/lib/currency_picker.dart
@@ -18,6 +18,7 @@ void showCurrencyPicker({
   currency_list.showCurrencyListBottomSheet(
     context: context,
     onSelect: onSelect,
+    currencyFilter: currencyFilter,
   );
 }
 

--- a/lib/currency_picker.dart
+++ b/lib/currency_picker.dart
@@ -1,5 +1,34 @@
 library currency_picker;
 
+import 'package:flutter/material.dart';
+
+import 'src/currency.dart';
+import 'src/currency_list_bottom_sheet.dart' as currency_list;
+
 export 'package:currency_picker/src/currency.dart';
-export 'package:currency_picker/src/currency_list_bottom_sheet.dart';
 export 'package:currency_picker/src/currency_service.dart';
+
+void showCurrencyPicker({
+  @required BuildContext context,
+  @required ValueChanged<Currency> onSelect,
+  List<String> currencyFilter,
+}) {
+  assert(context != null);
+  assert(onSelect != null);
+  currency_list.showCurrencyListBottomSheet(
+    context: context,
+    onSelect: onSelect,
+  );
+}
+
+@Deprecated('Use showCurrencyPicker instead. '
+    'This feature was deprecated after v1.0.2.')
+void showCurrencyListBottomSheet({
+  @required BuildContext context,
+  @required ValueChanged<Currency> onSelect,
+}) {
+  showCurrencyPicker(
+    context: context,
+    onSelect: onSelect,
+  );
+}

--- a/lib/src/currency_list_bottom_sheet.dart
+++ b/lib/src/currency_list_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'currency_list_view.dart';
 void showCurrencyListBottomSheet({
   @required BuildContext context,
   @required ValueChanged<Currency> onSelect,
+  List<String> currencyFilter,
 }) {
   assert(context != null);
   assert(onSelect != null);

--- a/lib/src/currency_list_bottom_sheet.dart
+++ b/lib/src/currency_list_bottom_sheet.dart
@@ -14,13 +14,14 @@ void showCurrencyListBottomSheet({
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
-    builder: (_) => _builder(context, onSelect),
+    builder: (_) => _builder(context, onSelect, currencyFilter),
   );
 }
 
 Widget _builder(
   BuildContext context,
   ValueChanged<Currency> onSelect,
+  List<String> currencyFilter,
 ) {
   final device = MediaQuery.of(context).size.height;
   final statusBarHeight = MediaQuery.of(context).padding.top;
@@ -46,6 +47,7 @@ Widget _builder(
     ),
     child: CurrencyListView(
       onSelect: onSelect,
+      currencyFilter: currencyFilter,
     ),
   );
 }

--- a/lib/src/currency_list_view.dart
+++ b/lib/src/currency_list_view.dart
@@ -9,6 +9,9 @@ class CurrencyListView extends StatefulWidget {
   /// The currency picker passes the new value to the callback.
   final ValueChanged<Currency> onSelect;
 
+  /// Can be used to uses filter the Currency list (optional).
+  ///
+  /// It takes a list of Currency code.
   final List<String> currencyFilter;
 
   const CurrencyListView({Key key, this.onSelect, this.currencyFilter})

--- a/lib/src/currency_list_view.dart
+++ b/lib/src/currency_list_view.dart
@@ -9,7 +9,10 @@ class CurrencyListView extends StatefulWidget {
   /// The currency picker passes the new value to the callback.
   final ValueChanged<Currency> onSelect;
 
-  const CurrencyListView({Key key, this.onSelect}) : super(key: key);
+  final List<String> currencyFilter;
+
+  const CurrencyListView({Key key, this.onSelect, this.currencyFilter})
+      : super(key: key);
   @override
   _CurrencyListViewState createState() => _CurrencyListViewState();
 }

--- a/lib/src/currency_list_view.dart
+++ b/lib/src/currency_list_view.dart
@@ -30,6 +30,15 @@ class _CurrencyListViewState extends State<CurrencyListView> {
     _searchController = TextEditingController();
     _currencyList = _currencyService.getAll();
     _filteredList = <Currency>[];
+
+    if (widget.currencyFilter != null) {
+      final List<String> currencyFilter =
+          widget.currencyFilter.map((code) => code.toUpperCase()).toList();
+
+      _currencyList
+          .removeWhere((element) => !currencyFilter.contains(element.code));
+    }
+
     _filteredList.addAll(_currencyList);
     super.initState();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A flutter package to select a currency from a list of currencies.
 homepage: https://github.com/Daniel-Ioannou
 repository: https://github.com/Daniel-Ioannou/flutter_currency_picker
 
-version: 1.0.1
+version: 1.0.2
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
### In this version:
* Deprecated showCurrencyListBottomSheet. Use `showCurrencyPicker` instead.
* Add currency filter option.
    - Can be used to uses filter the currencies list.
    - It takes a list of currency code.
      ```Dart
      showCurrencyPicker(
        context: context,
        onSelect: (Currency currency) {
          print('Select currency: ${currency.name}');
        },
        currencyFilter: <String> ['EUR', 'GBP', 'USD', 'AUD', 'CAD', 'JPY', 'HKD', 'CHF', 'SEK', 'ILS'],
      );
      ``` 