### PR TITLE
Updated the name_plural and symbols

### DIFF
--- a/lib/src/currencies.dart
+++ b/lib/src/currencies.dart
@@ -1082,11 +1082,11 @@ List<Map<String, dynamic>> currencies = [
   {
     "code": "SRD",
     "name": "Suriname Dollar",
-    "symbol": "\$",
+    "symbol": "$",
     "flag": "SRD",
     "decimal_digits": 2,
     "number": 968,
-    "name_plural": "Suriname Dollar",
+    "name_plural": "Suriname Dollars",
     "thousands_separator": ",",
     "decimal_separator": ".",
     "space_between_amount_and_symbol": false,
@@ -1095,7 +1095,7 @@ List<Map<String, dynamic>> currencies = [
   {
     "code": "TTD",
     "name": "Trinidad and Tobago Dollar",
-    "symbol": "TT\$",
+    "symbol": "TT$\$",
     "flag": "TTD",
     "decimal_digits": 2,
     "number": 780,


### PR DESCRIPTION
name_plural was changed to Suriname Dollars
and the symbol to $ - https://en.wikipedia.org/wiki/Surinamese_dollar
Trinidad and Tobago Dollar has 2 symbols both $ and TT$ - https://en.wikipedia.org/wiki/Trinidad_and_Tobago_dollar