### PR TITLE
Fix the name of South Korea

### DIFF
--- a/lib/src/currencies.dart
+++ b/lib/src/currencies.dart
@@ -145,7 +145,7 @@ List<Map<String, dynamic>> currencies = [
   },
   {
     "code": "KRW",
-    "name": "Korea (South) Won",
+    "name": "South Korea Won",
     "symbol": "₩",
     "flag": "KRW",
     "decimal_digits": 0,


### PR DESCRIPTION
There isn't Korea (North) and Korea (South). They are North Korea and South Korea. Saying "Korea (South)" offended some Koreans. This PR fixes it.

Thanks for your work! 👍 