### PR TITLE
Currency Sign TextStyle Changeable

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,6 +31,9 @@ class HomePage extends StatelessWidget {
               showSearchField: true,
               showCurrencyName: true,
               showCurrencyCode: true,
+              theme: CurrencyPickerThemeData(
+                  currencySignTextStyle:
+                      TextStyle(color: Colors.red, fontSize: 25)),
               onSelect: (Currency currency) {
                 print('Select currency: ${currency.name}');
               },

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -49,14 +42,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.11"
+    version: "2.0.12"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,28 +66,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -127,21 +120,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/currency_list_view.dart
+++ b/lib/src/currency_list_view.dart
@@ -165,6 +165,8 @@ class _CurrencyListViewState extends State<CurrencyListView> {
         widget.theme?.titleTextStyle ?? _defaultTitleTextStyle;
     final TextStyle _subtitleTextStyle =
         widget.theme?.subtitleTextStyle ?? _defaultSubtitleTextStyle;
+    final _currencySignTextStyle =
+        widget.theme?.currencySignTextStyle ?? _defaultCurrencySignTextStyle;
 
     return Material(
       // Add Material Widget with transparent color
@@ -216,7 +218,7 @@ class _CurrencyListViewState extends State<CurrencyListView> {
                 padding: const EdgeInsets.symmetric(horizontal: 10),
                 child: Text(
                   currency.symbol,
-                  style: const TextStyle(fontSize: 18),
+                  style: _currencySignTextStyle,
                 ),
               ),
             ],
@@ -262,4 +264,9 @@ class _CurrencyListViewState extends State<CurrencyListView> {
   TextStyle get _defaultTitleTextStyle => const TextStyle(fontSize: 17);
   TextStyle get _defaultSubtitleTextStyle =>
       TextStyle(fontSize: 15, color: Theme.of(context).hintColor);
+  TextStyle get _defaultCurrencySignTextStyle => const TextStyle(
+        fontSize: 18,
+        color: Colors.black,
+        fontWeight: FontWeight.bold,
+      );
 }

--- a/lib/src/currency_picker_theme_data.dart
+++ b/lib/src/currency_picker_theme_data.dart
@@ -17,6 +17,9 @@ class CurrencyPickerThemeData {
   /// If null, the style will be set to [TextStyle(fontSize: 15, color: Theme.of(context).hintColor)]
   final TextStyle? subtitleTextStyle;
 
+  /// If null, the style will be set to [TextStyle(fontSize: 18, color: Colors.black,fontWeight: FontWeight.bold);]
+  final TextStyle? currencySignTextStyle;
+
   ///The flag size.
   ///
   /// If null, set to 25
@@ -32,6 +35,7 @@ class CurrencyPickerThemeData {
       this.flagSize,
       this.titleTextStyle,
       this.subtitleTextStyle,
+      this.currencySignTextStyle,
       this.backgroundColor,
       this.bottomSheetHeight});
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: "direct main"
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,28 +66,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -127,35 +120,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.15.0-7.0.dev <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
In this pull request, I did added an option to change the style of the currencySign ($, 💶) by adding currencySignTextStyle inside CurrencyPickerThemeData().
`showCurrencyPicker(
             //...
              theme: CurrencyPickerThemeData(
                  currencySignTextStyle:
                      TextStyle(color: Colors.red, fontSize: 25)),
            //...
            );`