### PR TITLE
add iqd currency

### DIFF
--- a/lib/src/currencies.dart
+++ b/lib/src/currencies.dart
@@ -1469,4 +1469,17 @@ List<Map<String, dynamic>> currencies = [
     "space_between_amount_and_symbol": false,
     "symbol_on_left": true,
   },
+  {
+    "code": "IQD",
+    "name": "Iraqi Dinar",
+    "symbol": "د.ع",
+    "flag": "IQD",
+    "decimal_digits": 3,
+    "number": 368,
+    "name_plural": "Iraqi dinars",
+    "thousands_separator": ",",
+    "decimal_separator": ".",
+    "space_between_amount_and_symbol": true,
+    "symbol_on_left": true
+  }
 ];


### PR DESCRIPTION
This update adds the IQD currency. The IQD, or Iraqi Dinar, is the official currency of Iraq and is used by millions of people around the world. The inclusion of this currency will make it easier for developers and businesses working with Iraqi markets.