### PR TITLE
Update currency_list_view.dart

### DIFF
--- a/lib/src/currency_list_view.dart
+++ b/lib/src/currency_list_view.dart
@@ -258,8 +258,8 @@ class _CurrencyListViewState extends State<CurrencyListView> {
       searchResult = _currencyList
           .where(
             (c) =>
-                c.name.toLowerCase().contains(query.toLowerCase()) ||
-                c.code.toLowerCase().contains(query.toLowerCase()),
+                c.name.toLowerCase().contains(query.toLowerCase().trim()) ||
+                c.code.toLowerCase().contains(query.toLowerCase().trim()),
           )
           .toList();
     }


### PR DESCRIPTION
When a user wants to use a search field and enters either leading or trailing space, the picker doesn't show that specified currency, so trimming the text in the text field would be better.